### PR TITLE
AITEAM-1: Set up tests for sagemaker inference endpoints

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,10 +71,15 @@ workflows:
             - dev:create-model-endpoint-config
           filters: *main-branch-only
 
+      - kitten-model-invoke:
+          requires:
+            - dev:deploy-model-to-endpoint
+          filters: *main-branch-only
+
       - promote-model-to-prod-endpoint:
           type: approval
           requires:
-            - dev:deploy-model-to-endpoint
+            - kitten-model-invoke
           filters: *main-branch-only
 
       - aws-sagemaker/create_endpoint_configuration:
@@ -132,5 +137,19 @@ jobs:
       - run:
           name: train and register model
           command: python ./kitten_model/train_register.py
-
-
+  kitten-model-invoke:
+    docker:
+      - image: python:3.11
+    environment:
+      BUCKET_NAME: << pipeline.parameters.bucket >>
+      REGION_NAME: << pipeline.parameters.region_name >>
+      MODEL_NAME: << pipeline.parameters.model_name >>
+      MODEL_DESC: << pipeline.parameters.model_desc >>
+    steps:
+      - checkout
+      - run:
+          name: install python dependencies
+          command: pip install -r ./kitten_model/requirements.txt --upgrade
+      - run:
+          name: invoke model
+          command: python ./kitten_model/invoke_and_eval.py

--- a/kitten_model/README.md
+++ b/kitten_model/README.md
@@ -1,6 +1,8 @@
-# Get a quick model going
+# Kitten Model examples
 
-This document assumes you have aleready done the OIDC/IAM setup in the main README.
+## Get a quick model going
+
+This document assumes you have already done the OIDC/IAM setup in the main README.
 
 To use this to generate a model package to work with, please go to SageMaker and setup a Studio.
 
@@ -13,3 +15,14 @@ Any subsequent runs of this workflow will create a new version of the model. You
 Thanks to Timothy Cheung who's post I cribbed this from: [https://circleci.com/blog/machine-learning-ci-cd-with-aws-sagemaker/](https://circleci.com/blog/machine-learning-ci-cd-with-aws-sagemaker/)
 
 This assumes you have setup the Environment Variable `SAGEMAKER_EXECUTION_ROLE_ARN` as descibed in the README.md in the root of this project.
+
+## Invoking and evaluating the model
+
+The creation of your model must be completed before this step is possible. The `invoke_and_eval.py` script gives you the framework you can use to perform the necessary tasks. It shows you, in python, how to:
+
+1. auth using the OIDC steps previously prepped
+1. prepare your data for invocation
+1. invoke the created endpoint (dev)
+1. receive your results
+
+In `.config/circle.yml`, you can see how this script could be run as a gate to promoting your model to a production environment.

--- a/kitten_model/invoke_and_eval.py
+++ b/kitten_model/invoke_and_eval.py
@@ -1,0 +1,92 @@
+import pandas as pd
+import boto3
+import sagemaker
+import io
+from io import StringIO
+import os
+import math
+from pprint import pprint
+
+###############################################################################
+# This section sets up necessary variables from the environment
+###############################################################################
+bucket = os.environ["BUCKET_NAME"]
+model_name = os.environ["MODEL_NAME"]
+region_name = os.environ["REGION_NAME"]
+role_arn = os.environ["SAGEMAKER_EXECUTION_ROLE_ARN"]
+web_identity_token = os.environ["CIRCLE_OIDC_TOKEN"]
+
+###############################################################################
+# This section authenticates and sets up the sagemaker client
+###############################################################################
+role = boto3.client("sts").assume_role_with_web_identity(
+    RoleArn=role_arn, RoleSessionName="assume-role", WebIdentityToken=web_identity_token
+)
+credentials = role["Credentials"]
+aws_access_key_id = credentials["AccessKeyId"]
+aws_secret_access_key = credentials["SecretAccessKey"]
+aws_session_token = credentials["SessionToken"]
+boto_session = boto3.Session(
+    region_name=region_name,
+    aws_access_key_id=aws_access_key_id,
+    aws_secret_access_key=aws_secret_access_key,
+    aws_session_token=aws_session_token,
+)
+sagemaker_client = boto_session.client(service_name="sagemaker")
+sagemaker_runtime_client = boto_session.client(service_name="sagemaker-runtime")
+sagemaker_session = sagemaker.Session(
+    boto_session=boto_session,
+    sagemaker_client=sagemaker_client,
+    sagemaker_runtime_client=sagemaker_runtime_client,
+    default_bucket=bucket,
+)
+
+###############################################################################
+# This section is for setting up your inputs that will be send to the model
+#
+# While this is a sample, inputs (and formats) pertinent to your model will
+# be required here to get results that you can reasonably validate later
+###############################################################################
+read_bucket = "sagemaker-sample-files"
+read_prefix = "datasets/tabular/uci_abalone/test_csv"
+
+# # S3 location of test data
+test_data_uri = f"s3://{read_bucket}/{read_prefix}/abalone_dataset1_test.csv" 
+test_df = pd.read_csv(test_data_uri)
+
+# This is the inference request serialization step
+# CSV serialization
+csv_file = io.StringIO()
+test_df.to_csv(csv_file, sep=",", header=False, index=False)
+payload = csv_file.getvalue()
+
+###############################################################################
+# This section is where the inputs are sent to your trained model
+# https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker-runtime/client/invoke_endpoint.html
+#
+# The endpoint name will be the dev variant, before approving for prod deploy
+###############################################################################
+endpoint_name=model_name + "-dev"
+response = sagemaker_runtime_client.invoke_endpoint(
+            EndpointName=endpoint_name,
+            Body=payload,
+            ContentType="text/csv",
+            Accept="text/csv"
+            )
+
+###############################################################################
+# This section is where you can extract and interpret the results
+#
+# Again, this will be specific to your model, and you can use this to
+# print results, and even throw errors, to help decide if the current model
+# is ready for production deployment
+###############################################################################
+result = response["Body"].read()
+# Decoding bytes to a string
+result = result.decode("utf-8")
+# Converting to list of predictions
+result = result.strip("\n").split("\n")
+result = [math.ceil(float(i)) for i in result]
+prediction_df = pd.DataFrame()
+prediction_df["Prediction"] = result[:5]
+print(prediction_df)

--- a/kitten_model/requirements.txt
+++ b/kitten_model/requirements.txt
@@ -4,3 +4,5 @@ pandas==2.1.3
 boto3==1.29.3
 sagemaker==2.197.0
 requests==2.31.0
+fsspec==2024.2.0
+s3fs==2024.2.0


### PR DESCRIPTION
This provides a quasi-template and guide for other engineers to approach an invocation of their endpoint, and steps to evaluate. The script will hit an existing endpoint with some AWS provided sample data, then look at the results. No decisions are made as to the validity of those results, this would be left as an exercise to the person(s) who are creating and evaluating their models.

The new job step will run after a dev endpoint has been created, and before the "gate" for promoted to prod.

TBD: additional instructions in `kitten_model/README.md` to reflect comments within `invoke_and_eval.py`

This is what a run of this looks like on a personal repo:
![image](https://github.com/CircleCI-Public/sagemaker-deploy-examples/assets/43587711/bc796753-c239-4460-beb5-1e893915bced)
